### PR TITLE
React native 0.63 types part 2 - ColorValue

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -863,7 +863,7 @@ export interface TextStyleAndroid extends ViewStyle {
 
 // @see https://facebook.github.io/react-native/docs/text.html#style
 export interface TextStyle extends TextStyleIOS, TextStyleAndroid, ViewStyle {
-    color?: string;
+    color: ColorValue;
     fontFamily?: string;
     fontSize?: number;
     fontStyle?: 'normal' | 'italic';
@@ -1304,7 +1304,7 @@ export interface TextInputAndroidProps {
     /**
      * The color of the textInput underline.
      */
-    underlineColorAndroid?: string;
+    underlineColorAndroid?: ColorValue;
 
     /**
      * Vertically align text when `multiline` is set to true
@@ -2850,7 +2850,7 @@ export interface ActivityIndicatorProps extends ViewProps {
     /**
      * The foreground color of the spinner (default is gray).
      */
-    color?: string;
+    color?: ColorValue;
 
     /**
      * Whether the indicator should hide when not animating (true by default).
@@ -2884,7 +2884,7 @@ export interface ActivityIndicatorIOSProps extends ViewProps {
     /**
      * The foreground color of the spinner (default is gray).
      */
-    color?: string;
+    color: ColorValue;
 
     /**
      * Whether the indicator should hide when not animating (true by default).
@@ -3104,7 +3104,7 @@ export class PickerIOSItem extends React.Component<PickerIOSItemProps> {}
  */
 export interface PickerItemProps {
     testID?: string;
-    color?: string;
+    color: ColorValue;
     label: string;
     value?: any;
 }
@@ -3253,7 +3253,7 @@ export interface ProgressBarAndroidProps extends ViewProps {
     /**
      * Color of the progress bar.
      */
-    color?: string;
+    color: ColorValue;
 
     /**
      * Used to locate this view in end-to-end tests.
@@ -3334,7 +3334,7 @@ export interface RefreshControlPropsAndroid extends ViewProps {
     /**
      * The colors (at least one) that will be used to draw the refresh indicator.
      */
-    colors?: string[];
+    colors?: ColorValue[];
 
     /**
      * Whether the pull to refresh functionality is enabled.
@@ -5341,7 +5341,7 @@ export class TouchableNativeFeedback extends TouchableNativeFeedbackBase {
      * @param color The ripple color
      * @param borderless If the ripple can render outside it's bounds
      */
-    static Ripple(color: string, borderless?: boolean): RippleBackgroundPropType;
+    static Ripple(color: ColorValue, borderless?: boolean): RippleBackgroundPropType;
     static canUseNativeForeground(): boolean;
 }
 
@@ -7333,7 +7333,7 @@ export interface BackHandlerStatic {
 export interface ButtonProps {
     title: string;
     onPress: (ev: NativeSyntheticEvent<NativeTouchEvent>) => void;
-    color?: string;
+    color: ColorValue;
     accessibilityLabel?: string;
     disabled?: boolean;
 
@@ -8142,7 +8142,7 @@ export class StatusBar extends React.Component<StatusBarProps> {
      * @param color Background color.
      * @param animated Animate the style change.
      */
-    static setBackgroundColor: (color: string, animated?: boolean) => void;
+    static setBackgroundColor: (color: ColorValue, animated?: boolean) => void;
 
     /**
      * Control the translucency of the status bar
@@ -8445,7 +8445,7 @@ export interface SwitchProps extends SwitchPropsIOS {
      *
      * Color when false and color when true
      */
-    trackColor?: { false: string; true: string };
+    trackColor?: { false: ColorValue; true: ColorValue };
 
     /**
      * If true the user won't be able to toggle the switch.

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -863,7 +863,7 @@ export interface TextStyleAndroid extends ViewStyle {
 
 // @see https://facebook.github.io/react-native/docs/text.html#style
 export interface TextStyle extends TextStyleIOS, TextStyleAndroid, ViewStyle {
-    color: ColorValue;
+    color?: ColorValue;
     fontFamily?: string;
     fontSize?: number;
     fontStyle?: 'normal' | 'italic';
@@ -2884,7 +2884,7 @@ export interface ActivityIndicatorIOSProps extends ViewProps {
     /**
      * The foreground color of the spinner (default is gray).
      */
-    color: ColorValue;
+    color?: ColorValue;
 
     /**
      * Whether the indicator should hide when not animating (true by default).
@@ -3104,7 +3104,7 @@ export class PickerIOSItem extends React.Component<PickerIOSItemProps> {}
  */
 export interface PickerItemProps {
     testID?: string;
-    color: ColorValue;
+    color?: ColorValue;
     label: string;
     value?: any;
 }
@@ -3253,7 +3253,7 @@ export interface ProgressBarAndroidProps extends ViewProps {
     /**
      * Color of the progress bar.
      */
-    color: ColorValue;
+    color?: ColorValue;
 
     /**
      * Used to locate this view in end-to-end tests.
@@ -5911,14 +5911,14 @@ interface PlatformWebStatic extends PlatformStatic {
     OS: 'web';
 }
 
-// This needs to be any for now as setting it to the actual recursive type
-// Means the TS version needs to be updated, which causes the deps to fail
-// type ColorValue = any;
-type ColorValue = null | string | NativeColorValueIOS | NativeColorValueAndroid;
+export type ColorValue = null | string | NativeColorValueIOS | NativeColorValueAndroid;
+
 type ProcessedColorValueIOS = number | NativeColorValueIOS;
+
 type NativeColorValueAndroid = {
     resource_paths?: string[];
 };
+
 type NativeColorValueIOS = {
     semantic?: string[];
     dynamic?: {
@@ -7333,7 +7333,7 @@ export interface BackHandlerStatic {
 export interface ButtonProps {
     title: string;
     onPress: (ev: NativeSyntheticEvent<NativeTouchEvent>) => void;
-    color: ColorValue;
+    color?: ColorValue;
     accessibilityLabel?: string;
     disabled?: boolean;
 

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -65,6 +65,7 @@
 import * as React from 'react';
 
 type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+type Opaque<K, T> = T & { __TYPE__: K };
 
 type Constructor<T> = new (...args: any[]) => T;
 
@@ -5911,21 +5912,27 @@ interface PlatformWebStatic extends PlatformStatic {
     OS: 'web';
 }
 
-export type ColorValue = null | string | NativeColorValueIOS | NativeColorValueAndroid;
+type ColorValue = null | string | NativeColorValueIOS | NativeColorValueAndroid;
 
 type ProcessedColorValueIOS = number | NativeColorValueIOS;
 
-type NativeColorValueAndroid = {
-    resource_paths?: string[];
-};
+type NativeColorValueAndroid = Opaque<
+    '__NativeColorValueAndroid__',
+    {
+        resource_paths?: string[];
+    }
+>;
 
-type NativeColorValueIOS = {
-    semantic?: string[];
-    dynamic?: {
-        light?: ColorValue | ProcessedColorValueIOS;
-        dark?: ColorValue | ProcessedColorValueIOS;
-    };
-};
+type NativeColorValueIOS = Opaque<
+    '__NativeColorValueIOS__',
+    {
+        semantic?: string[];
+        dynamic?: {
+            light?: ColorValue | ProcessedColorValueIOS;
+            dark?: ColorValue | ProcessedColorValueIOS;
+        };
+    }
+>;
 
 type DynamicColorIOSTuple = {
     light: ColorValue;

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -736,7 +736,7 @@ export interface ShadowPropTypesIOSStatic {
      * Sets the drop shadow color
      * @platform ios
      */
-    shadowColor: string;
+    shadowColor: ColorValue;
 
     /**
      * Sets the drop shadow offset
@@ -851,7 +851,7 @@ export type FontVariant = 'small-caps' | 'oldstyle-nums' | 'lining-nums' | 'tabu
 export interface TextStyleIOS extends ViewStyle {
     fontVariant?: FontVariant[];
     letterSpacing?: number;
-    textDecorationColor?: string;
+    textDecorationColor?: ColorValue;
     textDecorationStyle?: 'solid' | 'double' | 'dotted' | 'dashed';
     writingDirection?: 'auto' | 'ltr' | 'rtl';
 }
@@ -878,8 +878,8 @@ export interface TextStyle extends TextStyleIOS, TextStyleAndroid, ViewStyle {
     textAlign?: 'auto' | 'left' | 'right' | 'center' | 'justify';
     textDecorationLine?: 'none' | 'underline' | 'line-through' | 'underline line-through';
     textDecorationStyle?: 'solid' | 'double' | 'dotted' | 'dashed';
-    textDecorationColor?: string;
-    textShadowColor?: string;
+    textDecorationColor?: ColorValue;
+    textShadowColor?: ColorValue;
     textShadowOffset?: { width: number; height: number };
     textShadowRadius?: number;
     textTransform?: 'none' | 'capitalize' | 'uppercase' | 'lowercase';
@@ -913,7 +913,7 @@ export interface TextPropsAndroid {
     /**
      * The highlight color of the text.
      */
-    selectionColor?: string;
+    selectionColor?: ColorValue;
 
     /**
      * Set text break strategy on Android API Level 23+
@@ -1569,7 +1569,7 @@ export interface TextInputProps extends ViewProps, TextInputIOSProps, TextInputA
     /**
      * The text color of the placeholder string
      */
-    placeholderTextColor?: string;
+    placeholderTextColor?: ColorValue;
 
     /**
      * enum('default', 'go', 'google', 'join', 'next', 'route', 'search', 'send', 'yahoo', 'done', 'emergency-call')
@@ -1597,7 +1597,7 @@ export interface TextInputProps extends ViewProps, TextInputIOSProps, TextInputA
     /**
      * The highlight (and cursor on ios) color of the text input
      */
-    selectionColor?: string;
+    selectionColor?: ColorValue;
 
     /**
      * Styles
@@ -1786,7 +1786,7 @@ export interface ToolbarAndroidProps extends ViewProps {
     /**
      * Sets the toolbar subtitle color.
      */
-    subtitleColor?: string;
+    subtitleColor?: ColorValue;
 
     /**
      * Used to locate this view in end-to-end tests.
@@ -1801,7 +1801,7 @@ export interface ToolbarAndroidProps extends ViewProps {
     /**
      * Sets the toolbar title color.
      */
-    titleColor?: string;
+    titleColor?: ColorValue;
 }
 
 /**
@@ -1955,23 +1955,23 @@ export interface GestureResponderHandlers {
  */
 export interface ViewStyle extends FlexStyle, ShadowStyleIOS, TransformsStyle {
     backfaceVisibility?: 'visible' | 'hidden';
-    backgroundColor?: string;
-    borderBottomColor?: string;
+    backgroundColor?: ColorValue;
+    borderBottomColor?: ColorValue;
     borderBottomEndRadius?: number;
     borderBottomLeftRadius?: number;
     borderBottomRightRadius?: number;
     borderBottomStartRadius?: number;
     borderBottomWidth?: number;
-    borderColor?: string;
-    borderEndColor?: string;
-    borderLeftColor?: string;
+    borderColor?: ColorValue;
+    borderEndColor?: ColorValue;
+    borderLeftColor?: ColorValue;
     borderLeftWidth?: number;
     borderRadius?: number;
-    borderRightColor?: string;
+    borderRightColor?: ColorValue;
     borderRightWidth?: number;
-    borderStartColor?: string;
+    borderStartColor?: ColorValue;
     borderStyle?: 'solid' | 'dotted' | 'dashed';
-    borderTopColor?: string;
+    borderTopColor?: ColorValue;
     borderTopEndRadius?: number;
     borderTopLeftRadius?: number;
     borderTopRightRadius?: number;
@@ -2652,7 +2652,7 @@ export interface SegmentedControlIOSProps extends ViewProps {
     /**
      * Accent color of the control.
      */
-    tintColor?: string;
+    tintColor?: ColorValue;
 
     /**
      * The labels for the control's segment buttons, in order.
@@ -2680,7 +2680,7 @@ export class SafeAreaView extends SafeAreaViewBase {}
 export class InputAccessoryView extends React.Component<InputAccessoryViewProps> {}
 
 export interface InputAccessoryViewProps {
-    backgroundColor?: string;
+    backgroundColor?: ColorValue;
 
     /**
      * An ID which is used to associate this InputAccessoryView to specified TextInput(s).
@@ -2725,7 +2725,7 @@ export interface NavigatorIOSProps {
     /**
      * The default background color of the navigation bar.
      */
-    barTintColor?: string;
+    barTintColor?: ColorValue;
 
     /**
      * NavigatorIOS uses "route" objects to identify child views, their props, and navigation bar configuration.
@@ -2765,12 +2765,12 @@ export interface NavigatorIOSProps {
     /**
      * The color used for buttons in the navigation bar
      */
-    tintColor?: string;
+    tintColor?: ColorValue;
 
     /**
      * The text color of the navigation bar title
      */
-    titleTextColor?: string;
+    titleTextColor?: ColorValue;
 
     /**
      * A Boolean value that indicates whether the navigation bar is translucent
@@ -2983,7 +2983,7 @@ export interface DrawerLayoutAndroidProps extends ViewProps {
      *   </DrawerLayoutAndroid>
      *);
      */
-    drawerBackgroundColor?: string;
+    drawerBackgroundColor?: ColorValue;
 
     /**
      * Specifies the lock mode of the drawer. The drawer can be locked
@@ -3059,7 +3059,7 @@ export interface DrawerLayoutAndroidProps extends ViewProps {
      * the status bar to allow it to open over the status bar. It will
      * only have an effect on API 21+.
      */
-    statusBarBackgroundColor?: string;
+    statusBarBackgroundColor?: ColorValue;
 }
 
 interface DrawerPosition {
@@ -3286,12 +3286,12 @@ export interface ProgressViewIOSProps extends ViewProps {
     /**
      * The tint color of the progress bar itself.
      */
-    progressTintColor?: string;
+    progressTintColor?: ColorValue;
 
     /**
      * The tint color of the progress bar track.
      */
-    trackTintColor?: string;
+    trackTintColor?: ColorValue;
 
     /**
      * A stretchable image to display as the progress bar.
@@ -3317,7 +3317,7 @@ export interface RefreshControlPropsIOS extends ViewProps {
     /**
      * The color of the refresh indicator.
      */
-    tintColor?: string;
+    tintColor?: ColorValue;
 
     /**
      * The title displayed under the refresh indicator.
@@ -3327,7 +3327,7 @@ export interface RefreshControlPropsIOS extends ViewProps {
     /**
      * Title color.
      */
-    titleColor?: string;
+    titleColor?: ColorValue;
 }
 
 export interface RefreshControlPropsAndroid extends ViewProps {
@@ -3344,7 +3344,7 @@ export interface RefreshControlPropsAndroid extends ViewProps {
     /**
      * The background color of the refresh indicator.
      */
-    progressBackgroundColor?: string;
+    progressBackgroundColor?: ColorValue;
 
     /**
      * Size of the refresh indicator, see RefreshControl.SIZE.
@@ -3430,7 +3430,7 @@ export interface SliderPropsAndroid extends ViewProps {
     /**
      * Color of the foreground switch grip.
      */
-    thumbTintColor?: string;
+    thumbTintColor?: ColorValue;
 }
 
 export interface SliderPropsIOS extends ViewProps {
@@ -3470,7 +3470,7 @@ export interface SliderProps extends SliderPropsIOS, SliderPropsAndroid {
      * The color used for the track to the right of the button.
      * Overrides the default blue gradient image.
      */
-    maximumTrackTintColor?: string;
+    maximumTrackTintColor?: ColorValue;
 
     /**
      * Initial maximum value of the slider. Default value is 1.
@@ -3481,7 +3481,7 @@ export interface SliderProps extends SliderPropsIOS, SliderPropsAndroid {
      * The color used for the track to the left of the button.
      * Overrides the default blue gradient image.
      */
-    minimumTrackTintColor?: string;
+    minimumTrackTintColor?: ColorValue;
 
     /**
      * Initial minimum value of the slider. Default value is 0.
@@ -3549,7 +3549,7 @@ export interface SwitchIOSProps extends ViewProps {
     /**
      * Background color when the switch is turned on.
      */
-    onTintColor?: string;
+    onTintColor?: ColorValue;
 
     /**
      * Callback that is called when the user toggles the switch.
@@ -3559,12 +3559,12 @@ export interface SwitchIOSProps extends ViewProps {
     /**
      * Background color for the switch round button.
      */
-    thumbTintColor?: string;
+    thumbTintColor?: ColorValue;
 
     /**
      * Background color when the switch is turned off.
      */
-    tintColor?: string;
+    tintColor?: ColorValue;
 
     /**
      * The value of the switch, if true the switch will be turned on. Default value is false.
@@ -3620,7 +3620,7 @@ export interface ImageResizeModeStatic {
 }
 
 export interface ShadowStyleIOS {
-    shadowColor?: string;
+    shadowColor?: ColorValue;
     shadowOffset?: { width: number; height: number };
     shadowOpacity?: number;
     shadowRadius?: number;
@@ -3636,15 +3636,15 @@ export interface ImageStyle extends FlexStyle, ShadowStyleIOS, TransformsStyle {
     backfaceVisibility?: 'visible' | 'hidden';
     borderBottomLeftRadius?: number;
     borderBottomRightRadius?: number;
-    backgroundColor?: string;
-    borderColor?: string;
+    backgroundColor?: ColorValue;
+    borderColor?: ColorValue;
     borderWidth?: number;
     borderRadius?: number;
     borderTopLeftRadius?: number;
     borderTopRightRadius?: number;
     overflow?: 'visible' | 'hidden';
-    overlayColor?: string;
-    tintColor?: string;
+    overlayColor?: ColorValue;
+    tintColor?: ColorValue;
     opacity?: number;
 }
 
@@ -5211,7 +5211,7 @@ export interface TouchableHighlightProps extends TouchableWithoutFeedbackProps {
     /**
      * The color of the underlay that will show through when the touch is active.
      */
-    underlayColor?: string;
+    underlayColor?: ColorValue;
 }
 
 /**
@@ -5709,7 +5709,7 @@ export interface TabBarIOSItemProps extends ViewProps {
     /**
      * Background color for the badge. Available since iOS 10.
      */
-    badgeColor?: string;
+    badgeColor?: ColorValue;
 
     /**
      * A custom icon for the tab. It is ignored when a system icon is defined.
@@ -5779,7 +5779,7 @@ export interface TabBarIOSProps extends ViewProps {
     /**
      * Background color of the tab bar
      */
-    barTintColor?: string;
+    barTintColor?: ColorValue;
 
     /**
      * Specifies tab bar item positioning. Available values are:
@@ -5795,7 +5795,7 @@ export interface TabBarIOSProps extends ViewProps {
     /**
      * Color of the currently selected tab icon
      */
-    tintColor?: string;
+    tintColor?: ColorValue;
 
     /**
      * A Boolean value that indicates whether the tab bar is translucent
@@ -5805,12 +5805,12 @@ export interface TabBarIOSProps extends ViewProps {
     /**
      * Color of text on unselected tabs
      */
-    unselectedTintColor?: string;
+    unselectedTintColor?: ColorValue;
 
     /**
      * Color of unselected tab icons. Available since iOS 10.
      */
-    unselectedItemTintColor?: string;
+    unselectedItemTintColor?: ColorValue;
 }
 
 export class TabBarIOS extends React.Component<TabBarIOSProps> {
@@ -5913,7 +5913,19 @@ interface PlatformWebStatic extends PlatformStatic {
 
 // This needs to be any for now as setting it to the actual recursive type
 // Means the TS version needs to be updated, which causes the deps to fail
-type ColorValue = any;
+// type ColorValue = any;
+type ColorValue = null | string | NativeColorValueIOS | NativeColorValueAndroid;
+type ProcessedColorValueIOS = number | NativeColorValueIOS;
+type NativeColorValueAndroid = {
+    resource_paths?: string[];
+};
+type NativeColorValueIOS = {
+    semantic?: string[];
+    dynamic?: {
+        light?: ColorValue | ProcessedColorValueIOS;
+        dark?: ColorValue | ProcessedColorValueIOS;
+    };
+};
 
 type DynamicColorIOSTuple = {
     light: ColorValue;
@@ -6508,7 +6520,7 @@ export interface ScrollViewPropsAndroid {
      * unnecessary overdraw. This is an advanced optimization that is not
      * needed in the general case.
      */
-    endFillColor?: string;
+    endFillColor?: ColorValue;
 
     /**
      * Tag used to log scroll performance on this scroll view. Will force
@@ -6895,7 +6907,7 @@ export interface ActionSheetIOSOptions {
     destructiveButtonIndex?: number;
     message?: string;
     anchor?: number;
-    tintColor?: string;
+    tintColor?: ColorValue;
 }
 
 export interface ShareActionSheetIOSOptions {
@@ -6957,7 +6969,7 @@ export type ShareContent =
 export type ShareOptions = {
     dialogTitle?: string;
     excludedActivityTypes?: Array<string>;
-    tintColor?: string;
+    tintColor?: ColorValue;
     subject?: string;
 };
 
@@ -8074,7 +8086,7 @@ export interface StatusBarPropsAndroid {
      *
      * @platform android
      */
-    backgroundColor?: string;
+    backgroundColor?: ColorValue;
 
     /**
      * If the status bar is translucent. When translucent is set to true,
@@ -8405,28 +8417,28 @@ export interface SwitchPropsIOS extends ViewProps {
      *
      * @deprecated use trackColor instead
      */
-    onTintColor?: string;
+    onTintColor?: ColorValue;
 
     /**
      * Color of the foreground switch grip.
      *
      * @deprecated use thumbColor instead
      */
-    thumbTintColor?: string;
+    thumbTintColor?: ColorValue;
 
     /**
      * Background color when the switch is turned off.
      *
      * @deprecated use trackColor instead
      */
-    tintColor?: string;
+    tintColor?: ColorValue;
 }
 
 export interface SwitchProps extends SwitchPropsIOS {
     /**
      * Color of the foreground switch grip.
      */
-    thumbColor?: string;
+    thumbColor?: ColorValue;
 
     /**
      * Custom colors for the switch track
@@ -8461,7 +8473,7 @@ export interface SwitchProps extends SwitchPropsIOS {
      * On iOS, custom color for the background.
      * Can be seen when the switch value is false or when the switch is disabled.
      */
-    ios_backgroundColor?: string;
+    ios_backgroundColor?: ColorValue;
 
     style?: StyleProp<ViewStyle>;
 }

--- a/types/react-native/test/index.tsx
+++ b/types/react-native/test/index.tsx
@@ -1186,6 +1186,9 @@ const OpaqueTest2 = () => (
     />
 );
 
+// Test you cannot ammend opaque type
+PlatformColor('?attr/colorControlNormal').resource_paths.push('foo'); // $ExpectError
+
 // Test PlatformColor inside Platform select with stylesheet
 StyleSheet.create({
     labelCell: {

--- a/types/react-native/test/index.tsx
+++ b/types/react-native/test/index.tsx
@@ -186,15 +186,6 @@ const stylesAlt = StyleSheet.create({
     },
 });
 
-// const stylesDynamicColor = StyleSheet.create({
-//     container: {
-//         flex: 1,
-//         justifyContent: 'center',
-//         alignItems: 'center',
-//         backgroundColor: DynamicColorIOS({light: '#ffffff', dark: '#eeeeee'}),
-//     },
-// });
-
 StyleSheet.setStyleAttributePreprocessor('fontFamily', (family: string) => family);
 
 const welcomeFontSize = StyleSheet.flatten(styles.welcome).fontSize;
@@ -1178,8 +1169,30 @@ StyleSheet.create({
             android: {
                 color: PlatformColor('?attr/colorControlNormal'),
             },
-            // default: { color: 'black' },
+            default: { color: PlatformColor('?attr/colorControlNormal') },
         }),
+    },
+});
+
+// PlatformColor in style colors
+StyleSheet.create({
+    labelCell: {
+        flex: 1,
+        alignItems: 'stretch',
+        color: PlatformColor('test'),
+        backgroundColor: PlatformColor('test'),
+        borderBottomColor: PlatformColor('test'),
+        borderColor: PlatformColor('test'),
+        borderEndColor: PlatformColor('test'),
+        borderLeftColor: PlatformColor('test'),
+        borderRightColor: PlatformColor('test'),
+        borderStartColor: PlatformColor('test'),
+        borderTopColor: PlatformColor('test'),
+        overlayColor: PlatformColor('test'),
+        shadowColor: PlatformColor('test'),
+        textDecorationColor: PlatformColor('test'),
+        textShadowColor: PlatformColor('test'),
+        tintColor: PlatformColor('test'),
     },
 });
 

--- a/types/react-native/test/index.tsx
+++ b/types/react-native/test/index.tsx
@@ -1159,6 +1159,33 @@ DynamicColorIOS({
     light: PlatformColor('labelColor'),
 });
 
+// Test you cannot set internals of ColorValue directly
+const OpaqueTest1 = () => (
+    <View
+        // $ExpectError
+        style={{
+            backgroundColor: {
+                resource_paths: ['?attr/colorControlNormal'],
+            },
+        }}
+    />
+);
+
+const OpaqueTest2 = () => (
+    <View
+        // $ExpectError
+        style={{
+            backgroundColor: {
+                semantic: 'string',
+                dynamic: {
+                    light: 'light',
+                    dark: 'dark',
+                },
+            },
+        }}
+    />
+);
+
 // Test PlatformColor inside Platform select with stylesheet
 StyleSheet.create({
     labelCell: {

--- a/types/react-native/test/index.tsx
+++ b/types/react-native/test/index.tsx
@@ -186,6 +186,15 @@ const stylesAlt = StyleSheet.create({
     },
 });
 
+// const stylesDynamicColor = StyleSheet.create({
+//     container: {
+//         flex: 1,
+//         justifyContent: 'center',
+//         alignItems: 'center',
+//         backgroundColor: DynamicColorIOS({light: '#ffffff', dark: '#eeeeee'}),
+//     },
+// });
+
 StyleSheet.setStyleAttributePreprocessor('fontFamily', (family: string) => family);
 
 const welcomeFontSize = StyleSheet.flatten(styles.welcome).fontSize;
@@ -1169,7 +1178,7 @@ StyleSheet.create({
             android: {
                 color: PlatformColor('?attr/colorControlNormal'),
             },
-            default: { color: 'black' },
+            // default: { color: 'black' },
         }),
     },
 });


### PR DESCRIPTION
This is part 2 of https://github.com/DefinitelyTyped/DefinitelyTyped/pull/45963

I've separated out this PR as this one just relates the the new `ColorValue` change which involved quite a few changes, so hopefully it will be easier to review in isolation


Note: it is showing the diff between `alexbrazier:react-native-0.63` and `alexbrazier:react-native-0.63-2`

Happy to merge this into https://github.com/DefinitelyTyped/DefinitelyTyped/pull/45963 once both are approved, or open this up as a second PR on https://github.com/DefinitelyTyped/DefinitelyTyped, whatever is preferred.